### PR TITLE
TE-1348 allow global logic `or`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ npm i --save bookshelf-modelbase-plus
 ```js
   Budget.getList(status: ['=', 'enabled'], ['status'])
 ```
+- Supports specifying logic, like
+```js
+  Budget.getList({a: 2, b: 3, _logic: 'or'})
+```
 - Supports Objects, like:
 ```js
   Budget.getList({

--- a/lib/index.js
+++ b/lib/index.js
@@ -115,9 +115,16 @@ module.exports = (bookshelf) => {
             if (_.isArray(value) && operator in searchChain) {
               return searchChain[operator](key, value);
             }
-            return searchChain.andWhere(key, operator, value);
-          }, searchChain.where(whereVals));
+            return searchChain[options._logic === 'or' ? 'orWhere' : 'andWhere'](key, operator, value);
+          }, this.whereQuery(searchChain, whereVals, options._logic));
           return search;
+        },
+
+        whereQuery: function(searchChain, whereVals, logic) {
+          if (logic !== 'or') {
+            return searchChain.where(whereVals); // default AND
+          }
+          return _.reduce(whereVals, (chain, v, k) => chain.orWhere({[k]: v}), searchChain);
         },
 
         sanitizeVal: function(val) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bookshelf-modelbase-plus",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Extended functionality for REST operations with validation, filtering, ordering, importing records.",
   "main": "./lib",
   "scripts": {

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -185,6 +185,17 @@ describe('database querying', () => {
           });
 
           [
+            [{email: 'email@user0.com', balance: 100, _logic: 'and'}, []],
+            [{email: 'email@user0.com', balance: 100, _logic: 'UNKNOWN'}, []],
+            [{email: 'email@user0.com', balance: 100}, []],
+            [{email: 'email@user0.com', balance: 100, _logic: 'or' }, [0, 1]],
+            [{email: 'email@user0.com', balance: 100, address: 'Address 2', _logic: 'or' }, [0, 1, 2]],
+          ].
+          it('should support or/and logic', (query, exp) => {
+            return userGetExp(query, exp);
+          });
+
+          [
             [{email: 'email@user0.com', _or: {email: 'email@user1.com'}}, [0, 1]],
             [{email: 'email@.com', _or: {email: 'email@user1.com'}}, [1]],
             [{email: 'email@user1.com', _and: {balance: ['!=', 100]}}, []],


### PR DESCRIPTION
Allow specifying global `_logic` (or/and)
- Default is still `and`
- Can still nest or/and logic as needed