### PR TITLE
Feature/pouuid fix

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -111,7 +111,7 @@ module.exports = (bookshelf) => {
               return chain;
             }
             operator = this.operators[operator];
-            value = this.sanitizeVal(value);
+            value = this.sanitizeVal(key, value);
             // between is special:
             if (_.isArray(value) && operator in searchChain) {
               return searchChain[operator.replace('and', options._logic || 'and')](key, value);
@@ -128,10 +128,13 @@ module.exports = (bookshelf) => {
           return _.reduce(whereVals, (chain, v, k) => chain.orWhere({[k]: v}), searchChain);
         },
 
-        sanitizeVal: function(val) {
+        sanitizeVal: function(key, val) {
           if (_.isArray(val)) {
-            return val.map(v => this.sanitizeVal(v));
+            return val.map(v => this.sanitizeVal(key, v));
           } else if (_.isString(val)) {
+            if (key in this.orderedUuids) {
+              return bookshelf.Model.binaryToPrefixedUuid(val, 2);
+            }
             str = val.toLowerCase();
             const maps = {
               'null': null,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bookshelf-modelbase-plus",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Extended functionality for REST operations with validation, filtering, ordering, importing records.",
   "main": "./lib",
   "scripts": {


### PR DESCRIPTION
bookshelf-prefixed-ordered-uuid transforms string queries into binary automatically ... but it doesn't seem to know how to work with nested queries... couldn't figure it out with knex either since the statement value gets set to a function ... so the easier fix is to transform strings to binary when building the search query