### PR TITLE
Added special keyword `withQuery` to getList

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,24 @@ npm i --save bookshelf-modelbase-plus
 - NOT_IN
 - NOT
 
+#### Special queries
+A function may optionally be defined on the model to be used when
+specifying `withQuery` in the getList options, similar to `withRelated`.
+This function will then be called with the knex query builder so that
+the model can define custom code to refine the search
+(i.e. join, convert values, etc.)
+
+Example:
+```js
+    var Budget = ModelBase.extend({
+        tableName: 'budgets'
+        fancy: (qb, options) => {
+          return qb.where({name: options.name + options.name2});
+        },
+    });
+    Budget.getList({name: 'first', name2: 'last', withQuery: 'fancy'})
+```
+
 ### model.createOne
 ```js
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -135,13 +135,14 @@ module.exports = (bookshelf) => {
         },
 
         withQuery: function(searchChain, options, specialFn) {
-          try {
-            const model = new this();
-            specialFn = _.isString(specialFn) ? specialFn.split(',') : specialFn;
-            return _.reduce(specialFn, (chain, fn) => model[fn](chain, options), searchChain);
-          } catch(e) {
-            return searchChain;
-          }
+          const model = new this();
+          specialFn = _.isString(specialFn) ? specialFn.split(',') : specialFn;
+          return _.reduce(specialFn, (chain, fn) => {
+            if (fn in model) {
+              return model[fn](chain, options);
+            }
+            throw new Error(`could not search withQuery ${fn}`);
+          }, searchChain);
         },
 
         whereQuery: function(searchChain, whereVals, logic) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -41,31 +41,39 @@ module.exports = (bookshelf) => {
         columnsError: 'Columns should be an array like [\'id\', \'name\', \'status\']',
         compositePKey: ['id'],
         operators: {
-        '!=': '!=',
-        'NOT_EQUAL_TO': '!=',
-        '<': '<',
-        'LESS_THAN': '<',
-        '<=': '<=',
-        'LESS_THAN_OR_EQUAL_TO': '<=',
-        '>': '>',
-        'GREATER_THAN': '>',
-        '>=': '>=',
-        'GREATER_THAN_OR_EQUAL_TO': '>=',
-        '=': '=',
-        'EQUAL_TO': '=',
-        'IS': 'IS',
-        'IS_NOT': 'IS NOT',
-        'IS NOT': 'IS NOT',
-        'LIKE': 'LIKE',
-        'NOT_LIKE': 'NOT LIKE',
-        'NOT LIKE': 'NOT LIKE',
-        'BETWEEN': 'andWhereBetween',
-        'NOT_BETWEEN': 'andWhereNotBetween',
-        'NOT BETWEEN': 'andWhereNotBetween',
-        'IN': 'IN',
-        'NOT_IN': 'NOT IN',
-        'NOT IN': 'NOT IN',
-      },
+          '!=': '!=',
+          'NOT_EQUAL_TO': '!=',
+          '<': '<',
+          'LESS_THAN': '<',
+          '<=': '<=',
+          'LESS_THAN_OR_EQUAL_TO': '<=',
+          '>': '>',
+          'GREATER_THAN': '>',
+          '>=': '>=',
+          'GREATER_THAN_OR_EQUAL_TO': '>=',
+          '=': '=',
+          'EQUAL_TO': '=',
+          'IS': 'IS',
+          'IS_NOT': 'IS NOT',
+          'IS NOT': 'IS NOT',
+          'LIKE': 'LIKE',
+          'NOT_LIKE': 'NOT LIKE',
+          'NOT LIKE': 'NOT LIKE',
+          'BETWEEN': 'andWhereBetween',
+          'NOT_BETWEEN': 'andWhereNotBetween',
+          'NOT BETWEEN': 'andWhereNotBetween',
+          'IN': 'IN',
+          'NOT_IN': 'NOT IN',
+          'NOT IN': 'NOT IN',
+        },
+        getListParams: [
+          'withRelated',
+          'debug',
+          'limit',
+          'page',
+          'order_by',
+          'withQuery',
+        ],
         eventEmitter,
         getList: function (options, columns) {
             return new Promise((resolve, reject) => {
@@ -91,7 +99,7 @@ module.exports = (bookshelf) => {
 
         toSearch: function(options, columns, searchChain) {
           const orAnd = ['_or', '_and'];
-          const filterNested = _.pick(options, columns.concat(orAnd));
+          const filterNested = _.pick(options, columns.concat(orAnd, 'withQuery'));
           const filter = _.pick(filterNested, columns);
           const whereVals = _.pickBy(filter, c => !_.isPlainObject(c) && !_.isArray(c));
           _.forEach(whereVals, (v, k) => whereVals[k] = this.sanitizeVal(k, v));
@@ -99,9 +107,11 @@ module.exports = (bookshelf) => {
             let operator, value;
             if (orAnd.indexOf(key) >= 0) {
               const bsThis = this;
-              return chain[key === orAnd[0] ? 'orWhere' : 'andWhere'](function() {
+              return chain[key === orAnd[0] ? 'orWhere' : 'andWhere'](function () {
                 bsThis.toSearch(item, columns, this);
               });
+            } else if (key === 'withQuery') {
+              return this.withQuery(searchChain, options, item);
             } else if (_.isPlainObject(item)) {
               operator = item.operator;
               value = item.value;
@@ -122,6 +132,16 @@ module.exports = (bookshelf) => {
             return searchChain[options._logic === 'or' ? 'orWhere' : 'andWhere'](key, operator, value);
           }, this.whereQuery(searchChain, whereVals, options._logic));
           return search;
+        },
+
+        withQuery: function(searchChain, options, specialFn) {
+          try {
+            const model = new this();
+            specialFn = _.isString(specialFn) ? specialFn.split(',') : specialFn;
+            return _.reduce(specialFn, (chain, fn) => model[fn](chain, options), searchChain);
+          } catch(e) {
+            return searchChain;
+          }
         },
 
         whereQuery: function(searchChain, whereVals, logic) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bookshelf-modelbase-plus",
-  "version": "2.5.8",
+  "version": "2.6.0",
   "description": "Extended functionality for REST operations with validation, filtering, ordering, importing records.",
   "main": "./lib",
   "scripts": {

--- a/test/db/models/user.js
+++ b/test/db/models/user.js
@@ -8,6 +8,9 @@ module.exports = ModelBase.extend({
     tableName: 'users',
     hasTimestamps: true,
     softDelete: true,
+    firstName: (qb, query) => {
+      return qb.where({first_name: query.fancy});
+    },
 });
 
 module.exports.columns = ['id', 'first_name', 'last_name', 'email', 'address', 'balance', 'created_at', 'updated_at', 'deleted_at'];

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -228,6 +228,10 @@ describe('database querying', () => {
           it('should support nested or/and', (query, exp) => {
             return userGetExp(query, exp);
           });
+
+          it('should support special withQuery functions', () => {
+            return userGetExp({withQuery: 'firstName', fancy: 'First Name User 2'}, [2]);
+          });
         });
 
         describe('update', () => {


### PR DESCRIPTION
Added `withQuery` option to `getList`, which allows adding any arbitrary functions to a model
- this can be used to perform joins, do special queries, or whatever the model defines, similar to bookshelfJS's `withRelated`
- multiple functions can be specified by comma-separated values
- the function is called with two arguments: the knex query builder, and the `options` that were passed into getList