### PR TITLE
TE-2069 bulk sync auto incrementing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -548,25 +548,25 @@ module.exports = (bookshelf) => {
           }
           const model = new this();
           const idAttribute = model.idAttribute || 'id';
-
-          if (returnInserted && (_.isEmpty(model.orderedUuids) || !(idAttribute in model.orderedUuids))) {
-            return Promise.reject(new Error('Could not return bulk-inserted rows with autoincremented PK in MySQL'));
-          }
+          const autoInc = returnInserted && (_.isEmpty(model.orderedUuids) || !(idAttribute in model.orderedUuids));
 
           return Promise
             .resolve()
             .then(() => this.bulkValidateSave(rows))
-            .then(() => rows.map(row => this.transformPouuidToBinary(row)))
-            .tap((data) => this
-              .knext(transacting)
-              .insert(data)
+            .then(() => rows = rows.map(row => this.transformPouuidToBinary(row)))
+            .then(() => this
+              .knext(autoInc ? null : transacting)
+              .insert(rows)
             )
-            .then((data) => {
+            .then((lastId) => {
               if (returnInserted) {
-                return this
-                  .knext(transacting)
+                let query = this.knext(transacting);
+                query = autoInc
+                  ? query.where(idAttribute, '>=', lastId)
+                  : query.whereIn(idAttribute, _.map(rows, idAttribute));
+                return query
+                  .limit(rows.length)
                   .select()
-                  .whereIn(idAttribute, _.map(data, idAttribute))
                   .map(r => this.transformBinaryToPouuid(r));
               }
               return rows.length;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bookshelf-modelbase-plus",
-  "version": "2.6.5",
+  "version": "2.6.6",
   "description": "Extended functionality for REST operations with validation, filtering, ordering, importing records.",
   "main": "./lib",
   "scripts": {


### PR DESCRIPTION
bulkSync method now handles auto-incrementing IDs  …
- do the insert outside of the transaction in order to get the insert ID back
- then query for all IDs >= that insert ID (limited by length inserted)