### PR TITLE
EX-318 Fix 'order_by' conflict on join

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -168,13 +168,15 @@ module.exports = (bookshelf) => {
                 const q = this
                     .query(qb => this.toSearch(options, columns, qb));
                 if (options.order_by || options.order_by === '') {
+                  const tableName = (new this()).tableName;
                   const order = _.castArray(options.order_by || new this().idAttribute || 'id')
                     .forEach((column) => {
                       if (column) {
+                        const columnName = col => col.includes('.') ? col : `${tableName}.${col}`;
                         if (column[0] === '-') {
-                          q.query(qb => qb.orderBy(column.slice(1), 'desc'));
+                          q.query(qb => qb.orderBy(columnName(column.slice(1)), 'desc'));
                         } else {
-                          q.query(qb => qb.orderBy(column, 'asc'));
+                          q.query(qb => qb.orderBy(columnName(column), 'asc'));
                         }
                       }
                     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bookshelf-modelbase-plus",
-  "version": "2.10.3",
+  "version": "2.10.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bookshelf-modelbase-plus",
-  "version": "2.10.3",
+  "version": "2.10.4",
   "description": "Extended functionality for REST operations with validation, filtering, ordering, importing records.",
   "main": "./lib",
   "scripts": {


### PR DESCRIPTION
- The default order is 'id', which can cause conflicts when joining tables if the table name is not specified