### PR TITLE
EX-320 table prefix

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -168,15 +168,13 @@ module.exports = (bookshelf) => {
                 const q = this
                     .query(qb => this.toSearch(options, columns, qb));
                 if (options.order_by || options.order_by === '') {
-                  const tableName = (new this()).tableName;
                   const order = _.castArray(options.order_by || new this().idAttribute || 'id')
                     .forEach((column) => {
                       if (column) {
-                        const columnName = col => col.includes('.') ? col : `${tableName}.${col}`;
                         if (column[0] === '-') {
-                          q.query(qb => qb.orderBy(columnName(column.slice(1)), 'desc'));
+                          q.query(qb => qb.orderBy(this.tableKey(column.slice(1)), 'desc'));
                         } else {
-                          q.query(qb => qb.orderBy(columnName(column), 'asc'));
+                          q.query(qb => qb.orderBy(this.tableKey(column), 'asc'));
                         }
                       }
                     });
@@ -200,7 +198,6 @@ module.exports = (bookshelf) => {
 
         toSearch: function(options, columns, searchChain) {
           columns = columns || this.columns;
-          const tableName = (new this()).tableName;
           const orAnd = ['_or', '_and'];
           const filterNested = _.pick(options, columns.concat(orAnd, 'withQuery'));
           const filter = _.pick(filterNested, columns);
@@ -232,14 +229,14 @@ module.exports = (bookshelf) => {
             // between is special:
             if (_.isArray(value) && operator in searchChain) {
               const searchMethod = options._logic === 'or' ? operator.replace('and', 'or') : operator;
-              return searchChain[searchMethod](`${tableName}.${key}`, value);
+              return searchChain[searchMethod](this.tableKey(key), value);
             }
             if (operator.includes('MATCH')) {
               const matchParts = operator.split(',');
               return searchChain[options._logic === 'or' ? 'orWhereRaw' : 'andWhereRaw'](
-                `${matchParts[0]} (??) AGAINST (? ${matchParts[1] || ''})`, [`${tableName}.${key}`, value]);
+                `${matchParts[0]} (??) AGAINST (? ${matchParts[1] || ''})`, [this.tableKey(key), value]);
             }
-            return searchChain[options._logic === 'or' ? 'orWhere' : 'andWhere'](`${tableName}.${key}`, operator, value);
+            return searchChain[options._logic === 'or' ? 'orWhere' : 'andWhere'](this.tableKey(key), operator, value);
           }, this.whereQuery(searchChain, whereVals, options._logic));
           return search;
         },
@@ -259,9 +256,12 @@ module.exports = (bookshelf) => {
           if (logic === 'none') {
             return searchChain;
           }
-          const tableName = (new this()).tableName;
           const chainMethod = (logic === 'or') ? 'orWhere' : 'where';
-          return _.reduce(whereVals, (chain, v, k) => chain[chainMethod](`${tableName}.${k}`, v), searchChain);
+          return _.reduce(whereVals, (chain, v, k) => chain[chainMethod](this.tableKey(k), v), searchChain);
+        },
+
+        tableKey: function(key, tableName = this.prototype.tableName) {
+          return key.includes('.') ? key : `${tableName}.${key}`;
         },
 
         sanitizeVal: function(key, val, operator = null) {
@@ -282,7 +282,6 @@ module.exports = (bookshelf) => {
           if (_.isArray(val)) {
             return val.map(v => this.sanitizeVal(key, v));
           } else if (_.isString(val)) {
-            const model = new this();
             const str = val.toLowerCase();
             const maps = {
               'null': null,
@@ -290,7 +289,7 @@ module.exports = (bookshelf) => {
               'false': false,
             };
             const safeVal = _.has(maps, str) ? maps[str] : val;
-            if (model.orderedUuids && key in model.orderedUuids) {
+            if (this.prototype.orderedUuids && key in this.prototype.orderedUuids) {
               return safeVal ? bookshelf.Model.prefixedUuidToBinary(safeVal, 2) : null;
             }
             return safeVal;
@@ -329,7 +328,7 @@ module.exports = (bookshelf) => {
                 const data = _.pick(options, updateColumns);
                 const findByKeys = options.findByCompositePKey
                   ? this.compositePKey
-                  : options.findByKeys || [new this().idAttribute || 'id'];
+                  : options.findByKeys || [this.prototype.idAttribute || 'id'];
                 const findArgs = options.findBy || _.pick(options, findByKeys);
                 if (!Object.keys(findArgs).length) {
                   return reject(this.NOT_FOUND);
@@ -428,7 +427,7 @@ module.exports = (bookshelf) => {
 
         importMany: function (options, columns, restoreModel = function() { return false; }) {
             // column names of the table that might be set/updated during import
-            const idAttribute = new this().idAttribute || 'id';
+            const idAttribute = this.prototype.idAttribute || 'id';
             const updateColumns = _.filter(columns, col => [idAttribute].indexOf(col) === -1);
             return new Promise((resolve, reject) => {
                 columns = columns || this.columns;
@@ -579,11 +578,10 @@ module.exports = (bookshelf) => {
          *   {Array<*>} unchanged
          */
         bulkSync: function(existingCollection, desiredRows, columns, {noInsert, noUpdate, noDestroy, isMatch} = {}) {
-            const model = new this();
-            if (existingCollection instanceof model.Collection) {
+            if (existingCollection instanceof this.prototype.Collection) {
               existingCollection = existingCollection.serialize();
             }
-            const idAttribute = model.idAttribute || 'id';
+            const idAttribute = this.prototype.idAttribute || 'id';
             const cols = this.columnFilter(columns);
             const beforeUpdates = {};
             const results = {
@@ -640,9 +638,8 @@ module.exports = (bookshelf) => {
           if (!Array.isArray(rows)) {
             return Promise.reject(new Error('`rows` is not an array'));
           }
-          const model = new this();
-          const idAttribute = model.idAttribute || 'id';
-          const autoInc = returnInserted && (_.isEmpty(model.orderedUuids) || !(idAttribute in model.orderedUuids));
+          const idAttribute = this.prototype.idAttribute || 'id';
+          const autoInc = returnInserted && (_.isEmpty(this.prototype.orderedUuids) || !(idAttribute in this.prototype.orderedUuids));
 
           return Promise
             .resolve()
@@ -690,7 +687,7 @@ module.exports = (bookshelf) => {
        * @returns {Promise<number>}
        */
         bulkDestroyIn: function(whereIn, { transacting } = {}) {
-          const idAttribute = new this().idAttribute || 'id';
+          const idAttribute = this.prototype.idAttribute || 'id';
           return Promise
             .resolve()
             .then(() => this
@@ -712,11 +709,10 @@ module.exports = (bookshelf) => {
           if (!Array.isArray(rows)) {
             return Promise.reject(new Error('`rows` is not an array'));
           }
-          const model = new this();
-          const idAttribute = model.idAttribute || 'id';
+          const idAttribute = this.prototype.idAttribute || 'id';
           let prevRows;
 
-          if (returnInserted && (_.isEmpty(model.orderedUuids) || !(idAttribute in model.orderedUuids))) {
+          if (returnInserted && (_.isEmpty(this.prototype.orderedUuids) || !(idAttribute in this.prototype.orderedUuids))) {
             return Promise.reject(new Error('Could not return bulk-inserted rows with autoincremented PK in MySQL'));
           }
 
@@ -751,8 +747,7 @@ module.exports = (bookshelf) => {
          * @returns {Promise<number|Array<*>>}
          */
         bulkUpdate: function(rows, columns = this.columns, { transacting, returnInserted, previous } = {}) {
-          const model = new this();
-          const idAttribute = model.idAttribute || 'id';
+          const idAttribute = this.prototype.idAttribute || 'id';
           let data;
 
           return Promise
@@ -760,7 +755,7 @@ module.exports = (bookshelf) => {
             .map(row => this.transformBinaryToPouuid(row))
             .tap(updatedRowsNotSaved => this.bulkValidateSave(updatedRowsNotSaved, columns))
             .tap((rows) => {
-              if (model.hasTimestamps) {
+              if (this.prototype.hasTimestamps) {
                 const key = _.isArray(this.hasTimestamps) ? this.hasTimestamps[1] : DEFAULT_TIMESTAMP_KEYS[1];
                 const now = new Date();
                 rows.forEach(r => r[key] = now);
@@ -769,8 +764,8 @@ module.exports = (bookshelf) => {
             .map(row => this.transformPouuidToBinary(row))
             .then((rows) => {
               const updateColumns = this.columnFilter(columns.length ? columns : Object.keys(rows[0]));
-              if (model.hasTimestamps) {
-                updateColumns.push(_.isArray(model.hasTimestamps) ? model.hasTimestamps[1] : DEFAULT_TIMESTAMP_KEYS[1]);
+              if (this.prototype.hasTimestamps) {
+                updateColumns.push(_.isArray(this.prototype.hasTimestamps) ? this.prototype.hasTimestamps[1] : DEFAULT_TIMESTAMP_KEYS[1]);
               }
               const updateColArr = updateColumns.map(e => `${e}=values(${e})`);
               data = rows;
@@ -810,8 +805,7 @@ module.exports = (bookshelf) => {
          * @returns {Promise<void>}
          */
         bulkValidateSave: function(rows, validateColumns = null, validateSaveOptions = { method: 'insert', patch: false }) {
-          const model = new this();
-          if (!(model.validate && model.validateSave)) {
+          if (!(this.prototype.validate && this.prototype.validateSave)) {
             return Promise.resolve();
           }
           const validationErrors = rows
@@ -841,15 +835,14 @@ module.exports = (bookshelf) => {
          * @returns {*}
          */
         knext: function(transacting = null) {
-          const model = new this();
-          return transacting ? bookshelf.knex(model.tableName).transacting(transacting) : bookshelf.knex(model.tableName);
+          const tableName = this.prototype.tableName;
+          return transacting ? bookshelf.knex(tableName).transacting(transacting) : bookshelf.knex(tableName);
         },
 
         columnFilter: function(columns, filter = null) {
           if (!filter) {
-            const model = new this();
-            const timeKeys = _.isArray(model.hasTimestamps) ? model.hasTimestamps : DEFAULT_TIMESTAMP_KEYS;
-            filter = [model.idAttribute || 'id', 'version', timeKeys[0], timeKeys[1]];
+            const timeKeys = _.isArray(this.prototype.hasTimestamps) ? this.prototype.hasTimestamps : DEFAULT_TIMESTAMP_KEYS;
+            filter = [this.prototype.idAttribute || 'id', 'version', timeKeys[0], timeKeys[1]];
           }
           return _.filter(columns || this.columns || [], col => filter.indexOf(col) === -1);
         },
@@ -862,21 +855,20 @@ module.exports = (bookshelf) => {
          * @returns {*}
          */
         transformPouuidToBinary: function(row, generateId = true) {
-          const model = new this();
           const r = Object.assign({}, row);
-          const idAttribute = model.idAttribute || 'id';
-          if (!_.isEmpty(model.orderedUuids)) {
+          const idAttribute = this.prototype.idAttribute || 'id';
+          if (!_.isEmpty(this.prototype.orderedUuids)) {
 
             if (typeof bookshelf.Model.prefixedUuidToBinary !== 'function') {
               throw new Error('bookshelf-prefixed-ordered-uuid is not installed but the model has orderedUuids');
             }
-            for (let k in model.orderedUuids) {
-              if (!model.orderedUuids.hasOwnProperty(k)) {
+            for (let k in this.prototype.orderedUuids) {
+              if (!this.prototype.orderedUuids.hasOwnProperty(k)) {
                 continue;
               }
               if (!(k in r) && k === idAttribute && generateId) {
                 // generate id
-                r[k] = bookshelf.Model.prefixedUuidToBinary(bookshelf.Model.generateUuid(model.orderedUuids[k]), 2);
+                r[k] = bookshelf.Model.prefixedUuidToBinary(bookshelf.Model.generateUuid(this.prototype.orderedUuids[k]), 2);
                 continue;
               }
 
@@ -896,13 +888,12 @@ module.exports = (bookshelf) => {
          * @returns {*}
          */
         transformBinaryToPouuid: function(row) {
-          const model = new this();
-          if (_.isEmpty(model.orderedUuids)) {
+          if (_.isEmpty(this.prototype.orderedUuids)) {
             return row;
           }
           const newRow = Object.assign({}, row);
           Object.keys(newRow).forEach((k) => {
-            if (k in model.orderedUuids && Buffer.isBuffer(newRow[k])) {
+            if (k in this.prototype.orderedUuids && Buffer.isBuffer(newRow[k])) {
               newRow[k] = bookshelf.Model.binaryToPrefixedUuid(newRow[k], 2);
             }
           });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bookshelf-modelbase-plus",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bookshelf-modelbase-plus",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "description": "Extended functionality for REST operations with validation, filtering, ordering, importing records.",
   "main": "./lib",
   "scripts": {


### PR DESCRIPTION
Table prefix update to ignore already table-prefixed keys in the query
- moved the check into a shared function
- use `this.prototype` instead of `new this()` when just wanting to obtain the ID or tableName